### PR TITLE
Support for i18n + fr and es translations

### DIFF
--- a/docs/gettext.iife.js
+++ b/docs/gettext.iife.js
@@ -1,0 +1,241 @@
+var i18n = (function () {
+   'use strict';
+
+   /*! gettext.js - Guillaume Potier - MIT Licensed */
+   var i18n = function (options) {
+    options = options || {};
+    // this.__version = '0.5.3';
+
+    // default values that could be overriden in i18n() construct
+    var defaults = {
+      domain: 'messages',
+      locale: (typeof document !== 'undefined' ? document.documentElement.getAttribute('lang') : false) || 'en',
+      plural_func: function (n) { return { nplurals: 2, plural: (n!=1) ? 1 : 0 }; },
+      ctxt_delimiter: String.fromCharCode(4) // \u0004
+    };
+
+    // handy mixins taken from underscode.js
+    var _ = {
+      isObject: function (obj) {
+        var type = typeof obj;
+        return type === 'function' || type === 'object' && !!obj;
+      },
+      isArray: function (obj) {
+        return toString.call(obj) === '[object Array]';
+      }
+    };
+
+    var
+      _plural_funcs = {},
+      _locale = options.locale || defaults.locale,
+      _domain = options.domain || defaults.domain,
+      _dictionary = {},
+      _plural_forms = {},
+      _ctxt_delimiter = options.ctxt_delimiter || defaults.ctxt_delimiter;
+
+      if (options.messages) {
+        _dictionary[_domain] = {};
+        _dictionary[_domain][_locale] = options.messages;
+      }
+
+      if (options.plural_forms) {
+        _plural_forms[_locale] = options.plural_forms;
+      }
+
+      // sprintf equivalent, takes a string and some arguments to make a computed string
+      // eg: strfmt("%1 dogs are in %2", 7, "the kitchen"); => "7 dogs are in the kitchen"
+      // eg: strfmt("I like %1, bananas and %1", "apples"); => "I like apples, bananas and apples"
+      // NB: removes msg context if there is one present
+      var strfmt = function (fmt) {
+         var args = arguments;
+
+         return fmt
+          // put space after double % to prevent placeholder replacement of such matches
+          .replace(/%%/g, '%% ')
+          // replace placeholders
+          .replace(/%(\d+)/g, function (str, p1) {
+            return args[p1];
+          })
+          // replace double % and space with single %
+          .replace(/%% /g, '%')
+      };
+
+      var removeContext = function(str) {
+         // if there is context, remove it
+         if (str.indexOf(_ctxt_delimiter) !== -1) {
+           var parts = str.split(_ctxt_delimiter);
+           return parts[1];
+         }
+
+       return str;
+      };
+
+      var expand_locale = function(locale) {
+          var locales = [locale],
+              i = locale.lastIndexOf('-');
+          while (i > 0) {
+              locale = locale.slice(0, i);
+              locales.push(locale);
+              i = locale.lastIndexOf('-');
+          }
+          return locales;
+      };
+
+      var getPluralFunc = function (plural_form) {
+        // Plural form string regexp
+        // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
+        // plural forms list available here http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
+        var pf_re = new RegExp('^\\s*nplurals\\s*=\\s*[0-9]+\\s*;\\s*plural\\s*=\\s*(?:\\s|[-\\?\\|&=!<>+*/%:;n0-9_\(\)])+');
+
+        if (!pf_re.test(plural_form))
+          throw new Error(strfmt('The plural form "%1" is not valid', plural_form));
+
+        // Careful here, this is a hidden eval() equivalent..
+        // Risk should be reasonable though since we test the plural_form through regex before
+        // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
+        // TODO: should test if https://github.com/soney/jsep present and use it if so
+        return new Function("n", 'var plural, nplurals; '+ plural_form +' return { nplurals: nplurals, plural: (plural === true ? 1 : (plural ? plural : 0)) };');
+      };
+
+      // Proper translation function that handle plurals and directives
+      // Contains juicy parts of https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
+      var t = function (messages, n, options /* ,extra */) {
+        // Singular is very easy, just pass dictionnary message through strfmt
+        if (1 === messages.length)
+         return strfmt.apply(this, [removeContext(messages[0])].concat(Array.prototype.slice.call(arguments, 3)));
+
+        var plural;
+
+        // if a plural func is given, use that one
+        if (options.plural_func) {
+          plural = options.plural_func(n);
+
+        // if plural form never interpreted before, do it now and store it
+        } else if (!_plural_funcs[_locale]) {
+          _plural_funcs[_locale] = getPluralFunc(_plural_forms[_locale]);
+          plural = _plural_funcs[_locale](n);
+
+        // we have the plural function, compute the plural result
+        } else {
+          plural = _plural_funcs[_locale](n);
+        }
+
+        // If there is a problem with plurals, fallback to singular one
+        if ('undefined' === typeof plural.plural || plural.plural > plural.nplurals || messages.length <= plural.plural)
+          plural.plural = 0;
+
+        return strfmt.apply(this, [removeContext(messages[plural.plural]), n].concat(Array.prototype.slice.call(arguments, 3)));
+      };
+
+    return {
+      strfmt: strfmt, // expose strfmt util
+      expand_locale: expand_locale, // expose expand_locale util
+
+      // Declare shortcuts
+      __: function () { return this.gettext.apply(this, arguments); },
+      _n: function () { return this.ngettext.apply(this, arguments); },
+      _p: function () { return this.pgettext.apply(this, arguments); },
+
+      setMessages: function (domain, locale, messages, plural_forms) {
+        if (!domain || !locale || !messages)
+          throw new Error('You must provide a domain, a locale and messages');
+
+        if ('string' !== typeof domain || 'string' !== typeof locale || !_.isObject(messages))
+          throw new Error('Invalid arguments');
+
+        if (plural_forms)
+          _plural_forms[locale] = plural_forms;
+
+        if (!_dictionary[domain])
+          _dictionary[domain] = {};
+
+        _dictionary[domain][locale] = messages;
+
+        return this;
+      },
+      loadJSON: function (jsonData, domain) {
+        if (!_.isObject(jsonData))
+          jsonData = JSON.parse(jsonData);
+
+        if (!jsonData[''] || !jsonData['']['language'] || !jsonData['']['plural-forms'])
+          throw new Error('Wrong JSON, it must have an empty key ("") with "language" and "plural-forms" information');
+
+        var headers = jsonData[''];
+        delete jsonData[''];
+
+        return this.setMessages(domain || defaults.domain, headers['language'], jsonData, headers['plural-forms']);
+      },
+      setLocale: function (locale) {
+        _locale = locale;
+        return this;
+      },
+      getLocale: function () {
+        return _locale;
+      },
+      // getter/setter for domain
+      textdomain: function (domain) {
+        if (!domain)
+          return _domain;
+        _domain = domain;
+        return this;
+      },
+      gettext: function (msgid /* , extra */) {
+        return this.dcnpgettext.apply(this, [undefined, undefined, msgid, undefined, undefined].concat(Array.prototype.slice.call(arguments, 1)));
+      },
+      ngettext: function (msgid, msgid_plural, n /* , extra */) {
+        return this.dcnpgettext.apply(this, [undefined, undefined, msgid, msgid_plural, n].concat(Array.prototype.slice.call(arguments, 3)));
+      },
+      pgettext: function (msgctxt, msgid /* , extra */) {
+        return this.dcnpgettext.apply(this, [undefined, msgctxt, msgid, undefined, undefined].concat(Array.prototype.slice.call(arguments, 2)));
+      },
+      dcnpgettext: function (domain, msgctxt, msgid, msgid_plural, n /* , extra */) {
+        domain = domain || _domain;
+
+        if ('string' !== typeof msgid)
+          throw new Error(this.strfmt('Msgid "%1" is not a valid translatable string', msgid));
+
+        var
+          translation,
+          options = {},
+          key = msgctxt ? msgctxt + _ctxt_delimiter + msgid : msgid,
+          exist,
+          locale,
+          locales = expand_locale(_locale);
+
+        for (var i in locales) {
+           locale = locales[i];
+           exist = _dictionary[domain] && _dictionary[domain][locale] && _dictionary[domain][locale][key];
+
+           // because it's not possible to define both a singular and a plural form of the same msgid,
+           // we need to check that the stored form is the same as the expected one.
+           // if not, we'll just ignore the translation and consider it as not translated.
+           if (msgid_plural) {
+             exist = exist && "string" !== typeof _dictionary[domain][locale][key];
+           } else {
+             exist = exist && "string" === typeof _dictionary[domain][locale][key];
+           }
+           if (exist) {
+             break;
+           }
+        }
+
+        if (!exist) {
+          translation = msgid;
+          options.plural_func = defaults.plural_func;
+        } else {
+          translation = _dictionary[domain][locale][key];
+        }
+
+        // Singular form
+        if (!msgid_plural)
+          return t.apply(this, [[translation], n, options].concat(Array.prototype.slice.call(arguments, 5)));
+
+        // Plural one
+        return t.apply(this, [exist ? translation : [msgid, msgid_plural], n, options].concat(Array.prototype.slice.call(arguments, 5)));
+      }
+    };
+   };
+
+   return i18n;
+
+}());

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,11 +12,11 @@
   </script>
   <meta charset="UTF-8">
   <meta property="og:title" content="ScreenCovid.com Online Covid Screening">
-<meta property="og:site_name" content="ScreenCovid.com">
-<meta property="og:url" content="https://screencovid.com">
-<meta property="og:description" content="">
-<meta property="og:type" content="website">
-<meta property="og:image" content="https://screencovid.com/images/covid19.jpg">
+  <meta property="og:site_name" content="ScreenCovid.com">
+  <meta property="og:url" content="https://screencovid.com">
+  <meta property="og:description" content="">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://screencovid.com/images/covid19.jpg">
   <title>ScreenCovid.com</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -26,6 +26,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.1.0/mustache.min.js"
     integrity="sha256-MPgtcamIpCPKRRm1ppJHkvtNBAuE71xcOM+MmQytXi8=" crossorigin="anonymous"></script>
+  <script src="gettext.iife.js"></script>
 
   <style>
     .symptomdescr {
@@ -37,7 +38,9 @@
       max-width: 500px;
     }
 
-
+    .info {
+      display: none;
+    }
 
     #container {
       width: 100%;
@@ -117,7 +120,8 @@
     }
 
     .avatar {
-      background: rgb(236, 240, 245);;
+      background: rgb(236, 240, 245);
+      ;
       width: -webkit-fill-available;
       height: 340px;
       display: block;
@@ -203,12 +207,10 @@
     }
 
     .checklist-label {
-  text-align: center !important; 
-  max-width: 375px !important; 
-  margin: 0 auto !important;
-}
-
-
+      text-align: center !important;
+      max-width: 375px !important;
+      margin: 0 auto !important;
+    }
   </style>
 </head>
 
@@ -222,36 +224,170 @@
         <div class="symptomdescr">{{question}}</div>
         <div class="avatar" style="display: block; background-image: url({{image_url}}); background-size: "></div>
             <div class="button-outer">
-          <div class="button-inner"><button class="ui-button ui-widget ui-corner-all button-no" id="no-button">NO</button></div>
-          <div class="button-inner"><button id="yes-button" class="ui-button ui-widget ui-corner-all button-yes">YES</button></div>
+          <div class="button-inner"><button class="ui-button ui-widget ui-corner-all button-no" id="no-button">{{no}}</button></div>
+          <div class="button-inner"><button id="yes-button" class="ui-button ui-widget ui-corner-all button-yes">{{yes}}</button></div>
               </div>
           </div>
 </script>
 
   <script>
+
+    var i18n = window.i18n({});
+
+    // default values MUST MATCH EXACTLY the values in the `list_of_questions`.
+    // I used Google Translate for 'es'.
+    // To add a new translation:
+    // - add a new entry for each question with a key that corresponds to the language.
+    // - make sure the language key is the one you tell people to use in the URL
+    // e.g. ?lang=fr or ?lang=es.
+    TRANSLATIONS =
+      [
+        {
+          'default': 'yes',
+          'fr': 'oui',
+          'es': 'sí'
+        },
+        {
+          'default': 'no',
+          'fr': 'non',
+          'es': 'no'
+        },
+        {
+          'default': 'Fever above 37.8C/100F in armpit or forehead?',
+          'fr': 'Fièvre supérieure à 37.8C/100F sous le bras ou sur le front',
+          'es': '¿Fiebre por encima de 37.8C / 100F en la axila o la frente?'
+        },
+        {
+          'default': 'Dry cough?',
+          'fr': 'Toux sèche ?',
+          'es': '¿Tos Seca?'
+        },
+        {
+          'default': 'Fatigue (feeling extra tired)?',
+          'fr': 'Fatigue ?',
+          'es': '¿ Fatiga ?'
+        },
+        {
+          'default': 'No appetite?',
+          'fr': 'Pas d\'apétit ?',
+          'es': '¿ Sin apetito?',
+        },
+        {
+          'default': 'Breathing difficulty?',
+          'fr': 'Difficultés à respirer ?',
+          'es': '¿ Dificultad respiratoria ?',
+        },
+        {
+          'default': 'Sputum (spitting or coughing lung mucus)?',
+          'fr': 'Expectorations',
+          'es': '¿ Esputo ?',
+        },
+        {
+          'default': 'Muscle or bone pain?',
+          'fr': 'Douleur musculaire ou osseuse ?',
+          'es': '¿ Dolor muscular o óseo ?',
+        },
+        {
+          'default': 'Sore throat?',
+          'fr': 'Gorge irritée ?',
+          'es': '¿ Dolor de garganta ?'
+        },
+        {
+          'default': 'Headache or dizziness?',
+          'fr': 'Maux de tête ou vertiges ?',
+          'es': '¿ Dolor de cabeza o mareos?'
+        },
+        {
+          'default': 'Confusion?',
+          'fr': 'Confusion ?',
+          'es': '¿ Confusión ?'
+        },
+        {
+          'default': 'Chills (cold or shivering)?',
+          'fr': 'Frissons ?',
+          'es': '¿ Resfriado ?'
+        },
+        {
+          'default': 'Nausea or vomiting or diarrhea?',
+          'fr': 'Nausées ou vomissements ou diarrhée ?',
+          'es': '¿ Náuseas o vómitos o diarrea ?'
+        },
+        {
+          'default': 'Chronic disease?',
+          'fr': 'Maladie chronique ?',
+          'es': '¿ Enfermedad crónica ?'
+        },
+        {
+          'default': 'Chest pain or chest pressure or irregular heartbeat?',
+          'fr': 'Douleur thoracique ou pression thoracique ou rythme cardiaque irrégulier ?',
+          'es': '¿ Dolor en el pecho o presión en el pecho o latidos cardíacos irregulares ?'
+        },
+        {
+          'default': 'Bluish lips or face?',
+          'fr': 'Lèvres ou visage bleutés ?',
+          'es': '¿ Labios o cara azulados ?'
+        },
+        {
+          'default': 'Older than 50 or younger than 5?',
+          'fr': 'Plus de 60 ans ou moins de 5 ans?',
+          'es': '¿ Mayor de 50 años o menor de 5 ?'
+        }
+      ]
+
+    // 'es': '¿ ?',
+    LANGUAGES = ['fr', 'es'];
+
+    LANGUAGES.forEach(language => {
+      var data = {};
+      TRANSLATIONS.forEach(item => {
+        if (language in item) {
+          data[item['default']] = item[language];
+        }
+      });
+      console.log(data);
+      i18n.setMessages('messages', language, data, 'nplurals=2; plural=n>1;');
+    });
+
+
+    const getQueryParams = (params, url, default_value) => {
+      let href = url;
+      //this expression is to get the query strings
+      let reg = new RegExp('[?&]' + params + '=([^&#]*)', 'i');
+      let queryString = reg.exec(href);
+      return queryString ? queryString[1] : default_value;
+    }; // source: https://dev.to/ganeshmani/how-to-get-query-string-parameters-in-javascript-2019-4dm2 .
+
+    // We extract the language; 'en' is the default one.
+    var lang = getQueryParams('lang', window.location, 'en');
+    console.log(lang)
+    i18n.setLocale(lang); // We set language for the UI.
+
+
+    // TODO: use contant values to make sure `list_of_qestions` and TRANSLATIONS are in sync.
     var list_of_questions = [
-      { 'id': 'q1', 'value': 90.5, 'question': 'Fever above 37.8C/100F in armpit or forehead?', 'image_url': 'images/fever.svg' },
-      { 'id': 'q2', 'value': 70.5, 'question': 'Dry cough?', 'image_url': 'images/cough.svg' },
-      { 'id': 'q3', 'value': 53.5, 'question': 'Fatigue (feeling extra tired)?', 'image_url': 'images/fatigue.svg' },
-      { 'id': 'q4', 'value': 40, 'question': 'No appetite?', 'image_url': 'images/no_appetite.svg' },
-      { 'id': 'q5', 'value': 250, 'question': 'Breathing difficulty?', 'image_url': 'images/difficulty_breathing.svg' },
-      { 'id': 'q6', 'value': 29.5, 'question': 'Sputum (spitting or coughing lung mucus)?', 'image_url': 'images/sputum.svg' },
-      { 'id': 'q7', 'value': 27.5, 'question': 'Muscle or bone pain?', 'image_url': 'images/body_pain.svg' },
-      { 'id': 'q8', 'value': 11, 'question': 'Sore throat?', 'image_url': 'images/sore_throat.svg' },
-      { 'id': 'q9', 'value': 10, 'question': 'Headache or dizziness?', 'image_url': 'images/headache.svg' },
-      { 'id': 'q10', 'value': 213, 'question': 'Confusion?', 'image_url': 'images/confusion.svg' },
-      { 'id': 'q11', 'value': 11, 'question': 'Chills (cold or shivering)?', 'image_url': 'images/chills.svg' },
-      { 'id': 'q12', 'value': 24, 'question': 'Nausea or vomiting or diarrhea?', 'image_url': 'images/nausea.svg' },
-      { 'id': 'q13', 'value': 51.9, 'question': 'Chronic disease?', 'image_url': 'images/chronic.svg' },
-      { 'id': 'q14', 'value': 215, 'question': 'Chest pain or chest pressure or irregular heartbeat?', 'image_url': 'images/heart.svg' },
-      { 'id': 'q15', 'value': 214, 'question': 'Bluish lips or face?', 'image_url': 'images/blue.svg' },
-      { 'id': 'q16', 'value': 51.9, 'question': 'Older than 50 or younger than 5?', 'image_url': 'images/man_and_child.svg' },
+      { 'id': 'q1', 'value': 90.5, 'question': i18n.gettext('Fever above 37.8C/100F in armpit or forehead?'), 'image_url': 'images/fever.svg' },
+      { 'id': 'q2', 'value': 70.5, 'question': i18n.gettext('Dry cough?'), 'image_url': 'images/cough.svg' },
+      { 'id': 'q3', 'value': 53.5, 'question': i18n.gettext('Fatigue (feeling extra tired)?'), 'image_url': 'images/fatigue.svg' },
+      { 'id': 'q4', 'value': 40, 'question': i18n.gettext('No appetite?'), 'image_url': 'images/no_appetite.svg' },
+      { 'id': 'q5', 'value': 250, 'question': i18n.gettext('Breathing difficulty?'), 'image_url': 'images/difficulty_breathing.svg' },
+      { 'id': 'q6', 'value': 29.5, 'question': i18n.gettext('Sputum (spitting or coughing lung mucus)?'), 'image_url': 'images/sputum.svg' },
+      { 'id': 'q7', 'value': 27.5, 'question': i18n.gettext('Muscle or bone pain?'), 'image_url': 'images/body_pain.svg' },
+      { 'id': 'q8', 'value': 11, 'question': i18n.gettext('Sore throat?'), 'image_url': 'images/sore_throat.svg' },
+      { 'id': 'q9', 'value': 10, 'question': i18n.gettext('Headache or dizziness?'), 'image_url': 'images/headache.svg' },
+      { 'id': 'q10', 'value': 213, 'question': i18n.gettext('Confusion?'), 'image_url': 'images/confusion.svg' },
+      { 'id': 'q11', 'value': 11, 'question': i18n.gettext('Chills (cold or shivering)?'), 'image_url': 'images/chills.svg' },
+      { 'id': 'q12', 'value': 24, 'question': i18n.gettext('Nausea or vomiting or diarrhea?'), 'image_url': 'images/nausea.svg' },
+      { 'id': 'q13', 'value': 51.9, 'question': i18n.gettext('Chronic disease?'), 'image_url': 'images/chronic.svg' },
+      { 'id': 'q14', 'value': 215, 'question': i18n.gettext('Chest pain or chest pressure or irregular heartbeat?'), 'image_url': 'images/heart.svg' },
+      { 'id': 'q15', 'value': 214, 'question': i18n.gettext('Bluish lips or face?'), 'image_url': 'images/blue.svg' },
+      { 'id': 'q16', 'value': 51.9, 'question': i18n.gettext('Older than 50 or younger than 5?'), 'image_url': 'images/man_and_child.svg' },
     ];
   </script>
 
   <!-- Toolbar -->
   <div data-role="header" style="background-color: #3c8dbc; border: none;">
-    <h1 style="text-shadow: none; color: #fff; font-size: 20px; padding: .6em 0; font-weight: 300; margin: 0 10%;">COVID-PreScreener</h1>
+    <h1 style="text-shadow: none; color: #fff; font-size: 20px; padding: .6em 0; font-weight: 300; margin: 0 10%;">
+      COVID-PreScreener</h1>
   </div>
 
   </br>
@@ -261,22 +397,39 @@
 
     <div id="questions"></div>
 
-   <div class="results" id="results"></div> 
+    <div class="results" id="results"></div>
 
   </div>
 
-<!-- Symptom Checklist -->
-<div class="widget">
-  <div id="checklist" class="controlgroup-vertical">
+  <!-- Symptom Checklist -->
+  <div class="widget">
+    <div id="checklist" class="controlgroup-vertical">
+    </div>
   </div>
-</div>
-</br>
+  </br>
 
   <div id="totaldescr">
-    <p>If you’re experiencing a life- or limb-threatening emergency, call 911 or the number for your local emergency
+    <p class="info lang-en">If you’re experiencing a life- or limb-threatening emergency, call 911 or the number for
+      your
+      local
+      emergency
       service.
       This tool is not a substitute for professional medical advice, diagnosis, or treatment. Always consult a medical
       professional for serious symptoms or emergencies. If the total exceeds 212, consult a doctor immediately</p>
+    <p class="info lang-es">Si tiene una emergencia que amenaza la vida o las extremidades, llame al 911 o al número de
+      su
+      local emergencia Servicio.
+      Esta herramienta no sustituye el consejo, el diagnóstico o el tratamiento médico profesional. Siempre consulte a
+      un médico
+      profesional para síntomas graves o emergencias. Si el total excede 212, consulte a un médico inmediatamente</p>
+    <p class="info lang-fr">Si vous vivez une urgence mettant en jeu votre vie ou vos membres, composez le 911 ou le
+      numéro
+      de votre
+      service d'urgence le plus proche.
+      Cet outil ne remplace pas les conseils, le diagnostic ou les traitement médicaux professionnels. Consultez
+      toujours un médecin
+      professionnel pour les symptômes graves ou les urgences. Si le total dépasse 212, consultez immédiatement un
+      médecin !</p>
   </div>
   <div id="total" class="total">
   </div>
@@ -315,14 +468,14 @@
       }
     }
 
-/* Display new checkbox and format style */
-displayCheckbox = function(h, ph) {
-  $("#" + h + "-label").css('display', 'block').css('border-bottom-width', '1px')
-      .css('border-bottom-left-radius', '5px').css('border-bottom-right-radius', '5px');
-  $("#" + ph + "-label").css('border-bottom-width', '0px')
-      .css('border-bottom-left-radius', '0px').css('border-bottom-right-radius', '0px');
-  return h;
-};
+    /* Display new checkbox and format style */
+    displayCheckbox = function (h, ph) {
+      $("#" + h + "-label").css('display', 'block').css('border-bottom-width', '1px')
+        .css('border-bottom-left-radius', '5px').css('border-bottom-right-radius', '5px');
+      $("#" + ph + "-label").css('border-bottom-width', '0px')
+        .css('border-bottom-left-radius', '0px').css('border-bottom-right-radius', '0px');
+      return h;
+    };
 
 
 
@@ -331,11 +484,17 @@ displayCheckbox = function(h, ph) {
 
     $(document).ready(function () {
 
-var prev_checkbox_id = ""
+      var prev_checkbox_id = ""
+
+      // We display the correct warning message.
+      $('.info').hide(); // We hide all info messages.
+      $('.info' + '.lang-' + lang).show(); // We display the one for the selected language.
 
       // We load the questions from template + JSON.
       var template = $('#covid19-template').html();
       $.each(list_of_questions, function (index, value) {
+        value['yes'] = i18n.gettext('yes');
+        value['no'] = i18n.gettext('no');
         var html = Mustache.to_html(template, value);
         $('#questions').append(html);
       });
@@ -359,28 +518,28 @@ var prev_checkbox_id = ""
 
       $(".buddy").one("swiperight", function () {
         totalscore = totalscore + parseFloat($(this).attr('value'));
-        
+
         $("#total").text(totalscore.toFixed(1));
         $(this).addClass('rotate-left').delay(700).fadeOut(1);
         $('.buddy').find('.status').remove();
 
         $(this).append('<div class="status like">Yes!</div>');
 
- /* Add item to checklist */
-      var checkbox_id = $(this).attr('id');
-      $("#" + checkbox_id + "-input").prop("checked", true).checkboxradio('refresh');
-      prev_checkbox_id = displayCheckbox(checkbox_id, prev_checkbox_id);
+        /* Add item to checklist */
+        var checkbox_id = $(this).attr('id');
+        $("#" + checkbox_id + "-input").prop("checked", true).checkboxradio('refresh');
+        prev_checkbox_id = displayCheckbox(checkbox_id, prev_checkbox_id);
 
         if ($(this).is(':last-child')) {
           //$('.buddy:nth-child(1)').removeClass ('rotate-left rotate-right').fadeIn(300);
           //alert('message here that we are done');
           //after survey is done additional messages should be displayed about next steps
-showResults();
-updateResults(totalscore);
+          showResults();
+          updateResults(totalscore);
         } else {
           $(this).next().removeClass('rotate-left rotate-right').fadeIn(400);
         }
-        
+
       });
 
       $(".buddy").one("swipeleft", function () {
@@ -388,48 +547,49 @@ updateResults(totalscore);
         $('.buddy').find('.status').remove();
         $(this).append('<div class="status dislike">No!</div>');
 
-           /* Add item to checklist */
-    var checkbox_id = $(this).attr('id');
-    prev_checkbox_id = displayCheckbox(checkbox_id, prev_checkbox_id);
+        /* Add item to checklist */
+        var checkbox_id = $(this).attr('id');
+        prev_checkbox_id = displayCheckbox(checkbox_id, prev_checkbox_id);
 
         if ($(this).is(':last-child')) {
           //$('.buddy:nth-child(1)').removeClass ('rotate-left rotate-right').fadeIn(300);
           //alert('message here that we are done');
           //after survey is done additional messages should be displayed about next steps
 
-showResults();
-updateResults(totalscore);
+          showResults();
+          updateResults(totalscore);
         } else {
           $(this).next().removeClass('rotate-left rotate-right').fadeIn(400);
         }
-        
+
       });
 
 
-  /* Generate symptom checklist */
-  list_of_questions.forEach(function(item) {
-    var input_id = item.id + "-input";
-    var label_id = item.id + "-label";
-    var list_item = '<label class="checklist-label" style="display: none;" id="' + 
-        label_id + '" for="' + input_id + '">' + item.question + '</label>' +
-        '<input style="display: none;" type="checkbox" id="' + input_id + '" value="' + item.value + '">';
-    $("#checklist").append(list_item);
-    $("#" + input_id).on('change', function() {
-      var symptom_value = item.value;
-      totalscore += $("#" + label_id).hasClass("ui-checkbox-on") ?  -symptom_value : symptom_value;
-      $("#total").text(totalscore.toFixed(1));
-      updateResults(totalscore);
-    });
-  });
-  $(function() {
-    $( ".controlgroup-vertical" ).controlgroup({
-      "direction": "vertical"
-    });
-  });
+      /* Generate symptom checklist */
+      list_of_questions.forEach(function (item) {
+        var input_id = item.id + "-input";
+        var label_id = item.id + "-label";
+        var list_item = '<label class="checklist-label" style="display: none;" id="' +
+          label_id + '" for="' + input_id + '">' + item.question + '</label>' +
+          '<input style="display: none;" type="checkbox" id="' + input_id + '" value="' + item.value + '">';
+        $("#checklist").append(list_item);
+        $("#" + input_id).on('change', function () {
+          var symptom_value = item.value;
+          totalscore += $("#" + label_id).hasClass("ui-checkbox-on") ? -symptom_value : symptom_value;
+          $("#total").text(totalscore.toFixed(1));
+          updateResults(totalscore);
+        });
+      });
+      $(function () {
+        $(".controlgroup-vertical").controlgroup({
+          "direction": "vertical"
+        });
+      });
 
     });
   </script>
-  
-  
- </body>
- </html>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
- using https://github.com/guillaumepotier/gettext.js library (I have included the `gettext.iife.js` file.

- TRANSLATIONS variable to hold the translation for each question.
The key is `default`, which must match EXACTLY the string being used.
Each language uses its own key, e.g. `fr`, `en`.
You can pick whatever key you want. But the should match the `lang` parameter.

- You can switch languages from via the query string, using `lang=`.

- For the main body of text (medical warning, etc.), I have added some CSS classes.
`<p class="info lang-fr">. I have some jQuery hiding all `info` first, then showing the elements that match `lang-VALUE` where `VALUE` is extracted from the URL. 

WARNING:
- if you change the phrasing of one question, you need to update TRANSLATION.
A better way would to define a canonical name for each question (and never change it) and then provide the English/default translation.